### PR TITLE
Make PP more extensible

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -286,14 +286,19 @@ class PP < PrettyPrint
       group(1, '{', '}') {
         seplist(obj, nil, :each_pair) {|k, v|
           group {
-            pp k
-            text '=>'
-            group(1) {
-              breakable ''
-              pp v
-            }
+            pp_hash_pair k, v
           }
         }
+      }
+    end
+
+    # A pretty print for a pair of Hash
+    def pp_hash_pair(k, v)
+      pp k
+      text '=>'
+      group(1) {
+        breakable ''
+        pp v
       }
     end
   end

--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -93,7 +93,7 @@ class PP < PrettyPrint
   #
   # PP.pp returns +out+.
   def PP.pp(obj, out=$>, width=width_for(out))
-    q = PP.new(out, width)
+    q = new(out, width)
     q.guard_inspect_key {q.pp obj}
     q.flush
     #$pp = q

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -245,4 +245,36 @@ if defined?(RubyVM)
   end
 end
 
+class PPInheritedTest < Test::Unit::TestCase
+  class PPSymbolHash < PP
+    def pp_hash(obj)
+      group(1, "{", "}") {
+        seplist(obj, nil, :each_pair) {|k, v|
+          case k
+          when Symbol
+            text k.inspect.delete_prefix(":")
+            text ":"
+            sep = " "
+          else
+            pp k
+            text "=>"
+            sep = ""
+          end
+          group(1) {
+            breakable sep
+            pp v
+          }
+        }
+      }
+    end
+  end
+
+  def test_hash_override
+    obj = {k: 1, "": :null, "0": :zero, 100 => :ten}
+    assert_equal <<~EXPECT, PPSymbolHash.pp(obj, "".dup)
+    {k: 1, "": :null, "0": :zero, 100=>:ten}
+    EXPECT
+  end
+end
+
 end

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -247,25 +247,18 @@ end
 
 class PPInheritedTest < Test::Unit::TestCase
   class PPSymbolHash < PP
-    def pp_hash(obj)
-      group(1, "{", "}") {
-        seplist(obj, nil, :each_pair) {|k, v|
-          case k
-          when Symbol
-            text k.inspect.delete_prefix(":")
-            text ":"
-            sep = " "
-          else
-            pp k
-            text "=>"
-            sep = ""
-          end
-          group(1) {
-            breakable sep
-            pp v
-          }
+    def pp_hash_pair(k, v)
+      case k
+      when Symbol
+        text k.inspect.delete_prefix(":")
+        text ":"
+        group(1) {
+          breakable
+          pp v
         }
-      }
+      else
+        super
+      end
     end
   end
 


### PR DESCRIPTION
Since `PP.pp` hardcodes `PP` to call its class method, `pp` method in inherited classes also uses `PP` instance instead of its owner class.
That means such class has to implement its own `pp`, or copy from `PP`.
The first commit in this PR makes this binding loose, and helps to implement such classes.