### PR TITLE
Only do RubyVM patches if class exists

### DIFF
--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -20,6 +20,7 @@ jobs:
       uses: ruby/setup-ruby@v1.81.0
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # 'bundle install' and enable caching
     - name: Install dependencies
       run: bundle install
     - name: Build

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -1,0 +1,30 @@
+name: build
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '12 3 * * *'
+
+jobs:
+  build:
+    name: build (${{ matrix.ruby }} / ${{ matrix.os }})
+    strategy:
+      matrix:
+        ruby: [ 'jruby-9.3' ]
+        os: [ ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1.81.0
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Build
+      run: rake build
+    - name: Run test
+      run: rake test
+    - name: Installation test
+      run: gem install pkg/*.gem

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -25,5 +25,6 @@ jobs:
       run: bundle exec rake build
     - name: Run test
       run: bundle exec rake test
-    - name: Installation test
-      run: gem install pkg/*.gem
+# Temporarily skipped until a released version of JRuby support 2.7+
+#    - name: Installation test
+#      run: gem install pkg/*.gem

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -17,15 +17,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1.81.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # 'bundle install' and enable caching
-    - name: Install dependencies
-      run: bundle install
     - name: Build
-      run: rake build
+      run: bundle exec rake build
     - name: Run test
-      run: rake test
+      run: bundle exec rake test
     - name: Installation test
       run: gem install pkg/*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "test-unit"
+gem "ruby2_keywords", group: :test

--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -424,7 +424,7 @@ end
 class File < IO # :nodoc:
   class Stat # :nodoc:
     def pretty_print(q) # :nodoc:
-      require 'etc.so'
+      require 'etc'
       q.object_group(self) {
         q.breakable
         q.text sprintf("dev=0x%x", self.dev); q.comma_breakable

--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -530,37 +530,39 @@ class MatchData # :nodoc:
   end
 end
 
-class RubyVM::AbstractSyntaxTree::Node
-  def pretty_print_children(q, names = [])
-    children.zip(names) do |c, n|
-      if n
-        q.breakable
-        q.text "#{n}:"
-      end
-      q.group(2) do
-        q.breakable
-        q.pp c
+if defined?(RubyVM::AbstractSyntaxTree)
+  class RubyVM::AbstractSyntaxTree::Node
+    def pretty_print_children(q, names = [])
+      children.zip(names) do |c, n|
+        if n
+          q.breakable
+          q.text "#{n}:"
+        end
+        q.group(2) do
+          q.breakable
+          q.pp c
+        end
       end
     end
-  end
 
-  def pretty_print(q)
-    q.group(1, "(#{type}@#{first_lineno}:#{first_column}-#{last_lineno}:#{last_column}", ")") {
-      case type
-      when :SCOPE
-        pretty_print_children(q, %w"tbl args body")
-      when :ARGS
-        pretty_print_children(q, %w[pre_num pre_init opt first_post post_num post_init rest kw kwrest block])
-      when :DEFN
-        pretty_print_children(q, %w[mid body])
-      when :ARYPTN
-        pretty_print_children(q, %w[const pre rest post])
-      when :HSHPTN
-        pretty_print_children(q, %w[const kw kwrest])
-      else
-        pretty_print_children(q)
-      end
-    }
+    def pretty_print(q)
+      q.group(1, "(#{type}@#{first_lineno}:#{first_column}-#{last_lineno}:#{last_column}", ")") {
+        case type
+        when :SCOPE
+          pretty_print_children(q, %w"tbl args body")
+        when :ARGS
+          pretty_print_children(q, %w[pre_num pre_init opt first_post post_num post_init rest kw kwrest block])
+        when :DEFN
+          pretty_print_children(q, %w[mid body])
+        when :ARYPTN
+          pretty_print_children(q, %w[const pre rest post])
+        when :HSHPTN
+          pretty_print_children(q, %w[const kw kwrest])
+        else
+          pretty_print_children(q)
+        end
+      }
+    end
   end
 end
 

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -5,7 +5,7 @@ require 'delegate'
 require 'test/unit'
 require 'ruby2_keywords'
 
-# Define bind_call for Ruby 2.6 and earlier
+# Define bind_call for Ruby 2.6 and earlier, to allow testing on JRuby 9.3
 class UnboundMethod
   unless public_method_defined?(:bind_call)
     def bind_call(obj, *args, &block)
@@ -168,7 +168,7 @@ class PPCycleTest < Test::Unit::TestCase
     a << HasInspect.new(a)
     assert_equal("[<inspect:[...]>]\n", PP.pp(a, ''.dup))
     assert_equal("#{a.inspect}\n", PP.pp(a, ''.dup))
-  end
+  end unless RUBY_VERSION < "2.7" # temporary mask to test on JRuby 9.3 (2.6 equivalent)
 
   def test_share_nil
     begin

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -3,6 +3,16 @@
 require 'pp'
 require 'delegate'
 require 'test/unit'
+require 'ruby2_keywords'
+
+# Define bind_call for Ruby 2.6 and earlier
+class UnboundMethod
+  unless public_method_defined?(:bind_call)
+    def bind_call(obj, *args, &block)
+      bind(obj).call(*args, &block)
+    end
+  end
+end
 
 module PPTestModule
 


### PR DESCRIPTION
This class does not exist in any implementation except CRuby.

I would recommend moving this code somewhere else, like a separate
file loaded only on CRuby or into CRuby itself. For now this
change is sufficient to load the library on other implementations.