### PR TITLE
Support BasicObject

### DIFF
--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -16,6 +16,17 @@ class PPTest < Test::Unit::TestCase
     assert_equal("[0,\n 1,\n 2,\n 3]\n", PP.pp([0,1,2,3], ''.dup, 11))
   end
 
+  def test_basic_object
+    foo_class = Class.new(Object) do
+      def initialize
+        @obj = BasicObject.new
+      end
+    end
+    assert_match(/#<BasicObject:.*>/, PP.pp(BasicObject.new, ''.dup, 12))
+    assert_match(/\[0,\n 1,\n 2,\n #<BasicObject:.*>\]\n/, PP.pp([0,1,2, BasicObject.new], ''.dup, 12))
+    assert_match(/#<#<Class:.*>:.*\n @obj=\n  #<BasicObject:.*>>/, PP.pp(foo_class.new, ''.dup, 12))
+  end
+
   OverriddenStruct = Struct.new("OverriddenStruct", :members, :class)
   def test_struct_override_members # [ruby-core:7865]
     a = OverriddenStruct.new(1,2)


### PR DESCRIPTION
When investigating https://github.com/ruby/irb/issues/540, I found that `pp` doesn't support `BasicObject`. Consider we start supporting it in tools like `irb` or `debug`, I think it may be good for `pp` to start supporting it too.