### PR TITLE
Update test/CI setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ head, '3.0', '2.7' ]
+        ruby: ['2.7', '3.0', '3.1', '3.2', 'head']
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         exclude:
         - { os: windows-latest, ruby: head }
         include:
         - { os: windows-latest, ruby: mingw }
         - { os: windows-latest, ruby: mswin }
-        - { os: ubuntu-latest, ruby: 'jruby-9.3', bundle: 'bundle exec' }
+        - { os: ubuntu-latest, ruby: 'jruby-head', bundle: 'bundle exec' }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -5,15 +5,6 @@ require 'delegate'
 require 'test/unit'
 require 'ruby2_keywords'
 
-# Define bind_call for Ruby 2.6 and earlier, to allow testing on JRuby 9.3
-class UnboundMethod
-  unless public_method_defined?(:bind_call)
-    def bind_call(obj, *args, &block)
-      bind(obj).call(*args, &block)
-    end
-  end
-end
-
 module PPTestModule
 
 class PPTest < Test::Unit::TestCase

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -173,11 +173,12 @@ class PPCycleTest < Test::Unit::TestCase
   end
 
   def test_withinspect
+    omit if RUBY_ENGINE == "jruby"
     a = []
     a << HasInspect.new(a)
     assert_equal("[<inspect:[...]>]\n", PP.pp(a, ''.dup))
     assert_equal("#{a.inspect}\n", PP.pp(a, ''.dup))
-  end unless RUBY_VERSION < "2.7" # temporary mask to test on JRuby 9.3 (2.6 equivalent)
+  end
 
   def test_share_nil
     begin
@@ -197,6 +198,7 @@ class PPSingleLineTest < Test::Unit::TestCase
   end
 
   def test_hash_in_array
+    omit if RUBY_ENGINE == "jruby"
     assert_equal("[{}]", PP.singleline_pp([->(*a){a.last.clear}.ruby2_keywords.call(a: 1)], ''.dup))
     assert_equal("[{}]", PP.singleline_pp([Hash.ruby2_keywords_hash({})], ''.dup))
   end


### PR DESCRIPTION
1. To keep the CRuby matrix up-to-date and inline with other projects.
2. Since `pp` now requires 2.7+, I don't think we should keep testing against JRuby 9.3, which aims to be 2.6 compatible.
3. To help other Ruby implementations match CRuby's behaviour, testing against their head version should be the most helpful.