### PR TITLE
Fix bug when call method pp with Thread.current[:__recursive_key__]

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -166,7 +166,10 @@ class PP < PrettyPrint
     def check_inspect_key(id)
       Thread.current[:__recursive_key__] &&
       Thread.current[:__recursive_key__][:inspect] &&
-      Thread.current[:__recursive_key__][:inspect].include?(id)
+      (
+        Thread.current[:__recursive_key__][:inspect].include?(id) ||
+        Thread.current[:__recursive_key__][:inspect].object_id == id.object_id
+      )
     end
 
     # Adds the object_id +id+ to the set of objects being pretty printed, so

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -171,6 +171,11 @@ class PPCycleTest < Test::Unit::TestCase
     assert_equal("#{a.inspect}\n", PP.pp(a, ''.dup))
   end
 
+  def test_thread_current_recursive_key
+    a = Thread.current[:__recursive_key__]
+    assert_equal("{:===>{}, :hash=>{}, :join=>{}, :nonzero?=>{}, :<=>=>{}, :inspect=>{...}}\n", PP.pp(a, ''.dup))
+  end
+
   def test_share_nil
     begin
       PP.sharing_detection = true


### PR DESCRIPTION
When I run this:
```ruby
PP.pp(Thread.current[:__recursive_key__], ''.dup)
```

Raises this error:
```
RuntimeError: can't add a new key into hash during iteration
```

I think that this error occours because of recursion hash in `Thread.current[:__recursive_key__][:inspect]`.

(PS: I found this bug searching the cause of [this bug](https://bugs.ruby-lang.org/issues/19738))