### PR TITLE
Print beginless ranges properly

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -442,7 +442,7 @@ end if "3.2" <= RUBY_VERSION
 
 class Range # :nodoc:
   def pretty_print(q) # :nodoc:
-    q.pp self.begin
+    q.pp self.begin if self.begin
     q.breakable ''
     q.text(self.exclude_end? ? '...' : '..')
     q.breakable ''

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -28,6 +28,13 @@ class PPTest < Test::Unit::TestCase
     end
     assert_equal(%(""\n), PP.pp(o, "".dup))
   end
+
+  def test_range
+    assert_equal("0..1\n", PP.pp(0..1, "".dup))
+    assert_equal("0...1\n", PP.pp(0...1, "".dup))
+    assert_equal("0...\n", PP.pp(0..., "".dup))
+    assert_equal("...1\n", PP.pp(...1, "".dup))
+  end
 end
 
 class HasInspect


### PR DESCRIPTION
Instead of displaying the start of the range as nil