### PR TITLE
Use fail-fast: false

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     needs: ruby-versions
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]


### PR DESCRIPTION
https://github.com/ruby/pp/actions/runs/7489634039/job/20386628987 canceled all other jobs even though it's a head a build, that's bad, so keep running other jobs if one fails.