### PR TITLE
Support new hash inspect style `{symbol_key: value}`

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -292,14 +292,35 @@ class PP < PrettyPrint
       }
     end
 
-    # A pretty print for a pair of Hash
-    def pp_hash_pair(k, v)
-      pp k
-      text '=>'
-      group(1) {
-        breakable ''
-        pp v
-      }
+    if RUBY_VERSION >= '3.4.'
+      # A pretty print for a pair of Hash
+      def pp_hash_pair(k, v)
+        if Symbol === k
+          sym_s = k.inspect
+          if sym_s[1].match?(/["$@!]/) || sym_s[-1].match?(/[%&*+\-\/<=>@\]^`|~]/)
+            text "#{k.to_s.inspect}:"
+          else
+            text "#{k}:"
+          end
+        else
+          pp k
+          text ' '
+          text '=>'
+        end
+        group(1) {
+          breakable
+          pp v
+        }
+      end
+    else
+      def pp_hash_pair(k, v)
+        pp k
+        text '=>'
+        group(1) {
+          breakable ''
+          pp v
+        }
+      end
     end
   end
 


### PR DESCRIPTION
Apply changes in https://github.com/ruby/ruby/pull/10924