### PR TITLE
`false..` `..false` and `nil..nil`

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -470,12 +470,13 @@ end if defined?(Data.define)
 
 class Range # :nodoc:
   def pretty_print(q) # :nodoc:
-    both_nil = self.begin == nil && self.end == nil
-    q.pp self.begin if self.begin != nil || both_nil
+    begin_nil = self.begin == nil
+    end_nil = self.end == nil
+    q.pp self.begin if !begin_nil || end_nil
     q.breakable ''
     q.text(self.exclude_end? ? '...' : '..')
     q.breakable ''
-    q.pp self.end if self.end != nil || both_nil
+    q.pp self.end if !end_nil || begin_nil
   end
 end
 

--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -470,11 +470,12 @@ end if defined?(Data.define)
 
 class Range # :nodoc:
   def pretty_print(q) # :nodoc:
-    q.pp self.begin if self.begin
+    both_nil = self.begin == nil && self.end == nil
+    q.pp self.begin if self.begin != nil || both_nil
     q.breakable ''
     q.text(self.exclude_end? ? '...' : '..')
     q.breakable ''
-    q.pp self.end if self.end
+    q.pp self.end if self.end != nil || both_nil
   end
 end
 

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -34,6 +34,10 @@ class PPTest < Test::Unit::TestCase
     assert_equal("0...1\n", PP.pp(0...1, "".dup))
     assert_equal("0...\n", PP.pp(0..., "".dup))
     assert_equal("...1\n", PP.pp(...1, "".dup))
+    assert_equal("..false\n", PP.pp(..false, "".dup))
+    assert_equal("false..\n", PP.pp(false.., "".dup))
+    assert_equal("false..false\n", PP.pp(false..false, "".dup))
+    assert_equal("nil..nil\n", PP.pp(nil..nil, "".dup))
   end
 end
 


### PR DESCRIPTION
`nil..nil` `nil..false` `false..nil` `false..false` was all displayed `..`

After this fix
```
$ ruby -Ilib -e binding.irb
irb(main):001> nil..false
=> ..false
irb(main):002> false..nil
=> false..
irb(main):003> false..false
=> false..false
irb(main):004> nil..nil
=> nil..nil
irb(main):005> 
```
Distinguishing `nil..nil` from `nil..false` will make it easy to debug when I mistakenly created wrong range.
