### PR TITLE
Data#pretty_print handle privated or removed members

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -451,13 +451,25 @@ class Data # :nodoc:
     class_name = PP.mcall(self, Kernel, :class).name
     class_name = " #{class_name}" if class_name
     q.group(1, "#<data#{class_name}", '>') {
-      q.seplist(PP.mcall(self, Kernel, :class).members, lambda { q.text "," }) {|member|
+
+      members = PP.mcall(self, Kernel, :class).members
+      values = []
+      members.select! do |member|
+        value = begin
+          values << __send__(member)
+          true
+        rescue NoMethodError
+          false
+        end
+      end
+
+      q.seplist(members.zip(values), lambda { q.text "," }) {|(member, value)|
         q.breakable
         q.text member.to_s
         q.text '='
         q.group(1) {
           q.breakable ''
-          q.pp public_send(member)
+          q.pp value
         }
       }
     }

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -159,6 +159,22 @@ class PPCycleTest < Test::Unit::TestCase
       b = Data.define(:a).new(42)
       assert_equal("#{b.inspect}\n", PP.pp(b, ''.dup))
     end
+
+    D2 = Data.define(:aaa, :bbb) do
+      private :aaa
+    end
+    def test_data_private_member
+      a = D2.new("aaa", "bbb")
+      assert_equal("#<data PPTestModule::PPCycleTest::D2\n aaa=\"aaa\",\n bbb=\"bbb\">\n", PP.pp(a, ''.dup, 20))
+    end
+
+    D3 = Data.define(:aaa, :bbb) do
+      remove_method :aaa
+    end
+    def test_data_removed_member
+      a = D3.new("aaa", "bbb")
+      assert_equal("#<data PPTestModule::PPCycleTest::D3\n bbb=\"bbb\">\n", PP.pp(a, ''.dup, 20))
+    end
   end
 
   def test_object


### PR DESCRIPTION
[Bug #20808]

The previous implementation assumed all members are accessible, but it's possible for users to change the visibility of members or to entirely remove the accessor.

cc @akr 