### PR TITLE
Avoid an array allocation per element in list passed to seplist

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -276,15 +276,20 @@ class PP < PrettyPrint
     def seplist(list, sep=nil, iter_method=:each) # :yield: element
       sep ||= lambda { comma_breakable }
       first = true
+      kwsplat = EMPTY_HASH
       list.__send__(iter_method) {|*v|
         if first
           first = false
         else
           sep.call
         end
-        RUBY_VERSION >= "3.0" ? yield(*v, **{}) : yield(*v)
+        kwsplat ? yield(*v, **kwsplat) : yield(*v)
       }
     end
+    EMPTY_HASH = if RUBY_VERSION >= "3.0"
+      {}.freeze
+    end
+    private_constant :EMPTY_HASH
 
     # A present standard failsafe for pretty printing any given Object
     def pp_object(obj)

--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -276,7 +276,7 @@ class PP < PrettyPrint
     def seplist(list, sep=nil, iter_method=:each) # :yield: element
       sep ||= lambda { comma_breakable }
       first = true
-      kwsplat = EMPTY_HASH
+      kwsplat = EMPTY_KWHASH
       list.__send__(iter_method) {|*v|
         if first
           first = false
@@ -286,10 +286,10 @@ class PP < PrettyPrint
         kwsplat ? yield(*v, **kwsplat) : yield(*v)
       }
     end
-    EMPTY_HASH = if RUBY_VERSION >= "3.0"
+    EMPTY_KWHASH = if RUBY_VERSION >= "3.0"
       {}.freeze
     end
-    private_constant :EMPTY_HASH
+    private_constant :EMPTY_KWHASH
 
     # A present standard failsafe for pretty printing any given Object
     def pp_object(obj)


### PR DESCRIPTION
The array allocation was because the keyword splat expression is not recognized as safe by the compiler.  Also avoid unnecessary `>=` method call per element.  This uses a private constant to avoid unnecessary work at runtime.

I assume the only reason this code is needed is because `v` may end with a `ruby2_keywords` hash that we do not want to treat as keywords.

This issue was found by the performance warning in Ruby feature 21274.