### PR TITLE
Support new instance_variables_to_inspect method from Ruby core

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -399,7 +399,8 @@ class PP < PrettyPrint
     # This method should return an array of names of instance variables as symbols or strings as:
     # +[:@a, :@b]+.
     def pretty_print_instance_variables
-      instance_variables.sort
+      ivars = respond_to?(:instance_variables_to_inspect) ? instance_variables_to_inspect : instance_variables
+      ivars.sort
     end
 
     # Is #inspect implementation using #pretty_print.

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -130,6 +130,20 @@ class PPInspectTest < Test::Unit::TestCase
     assert_equal("#{a.inspect}\n", result)
   end
 
+  def test_iv_hiding
+    a = Object.new
+    def a.pretty_print_instance_variables() [:@b] end
+    a.instance_eval { @a = "aaa"; @b = "bbb" }
+    assert_match(/\A#<Object:0x[\da-f]+ @b="bbb">\n\z/, PP.pp(a, ''.dup))
+  end
+
+  def test_iv_hiding_via_ruby
+    a = Object.new
+    def a.instance_variables_to_inspect() [:@b] end
+    a.instance_eval { @a = "aaa"; @b = "bbb" }
+    assert_match(/\A#<Object:0x[\da-f]+ @b="bbb">\n\z/, PP.pp(a, ''.dup))
+  end
+
   def test_basic_object
     a = BasicObject.new
     assert_match(/\A#<BasicObject:0x[\da-f]+>\n\z/, PP.pp(a, ''.dup))


### PR DESCRIPTION
This supports the new `instance_variables_to_inspect` method from Ruby core that was added in ruby/ruby#13555.

If `instance_variables_to_inspect` is defined, then `pretty_print_instance_variables` will use it.

Additionally, this commit introduces tests for both `pretty_print_instance_variables` and `instance_variables_to_inspect`.