### PR TITLE
Fix ::Data warning on Ruby 2.7

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -490,6 +490,13 @@ class Struct # :nodoc:
   end
 end
 
+verbose, $VERBOSE = $VERBOSE, nil
+begin
+  has_data_define = defined?(Data.define)
+ensure
+  $VERBOSE = verbose
+end
+
 class Data # :nodoc:
   def pretty_print(q) # :nodoc:
     class_name = PP.mcall(self, Kernel, :class).name
@@ -522,7 +529,7 @@ class Data # :nodoc:
   def pretty_print_cycle(q) # :nodoc:
     q.text sprintf("#<data %s:...>", PP.mcall(self, Kernel, :class).name)
   end
-end if defined?(Data.define)
+end if has_data_define
 
 class Range # :nodoc:
   def pretty_print(q) # :nodoc:

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -172,7 +172,14 @@ class PPCycleTest < Test::Unit::TestCase
     assert_equal("#{a.inspect}\n", PP.pp(a, ''.dup)) unless RUBY_ENGINE == "truffleruby"
   end
 
-  if defined?(Data.define)
+  verbose, $VERBOSE = $VERBOSE, nil
+  begin
+    has_data_define = defined?(Data.define)
+  ensure
+    $VERBOSE = verbose
+  end
+
+  if has_data_define
     D = Data.define(:aaa, :bbb)
     def test_data
       a = D.new("aaa", "bbb")


### PR DESCRIPTION
* It was showing on require 'pp': lib/pp.rb:525: warning: constant ::Data is deprecated
* Fixes https://github.com/ruby/pp/issues/51