### PR TITLE
Do not override the methods in set.rb

### DIFF
--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -453,11 +453,11 @@ class Set # :nodoc:
         }
       }
     }
-  end
+  end unless method_defined?(:pretty_print)
 
   def pretty_print_cycle(pp)    # :nodoc:
     pp.text sprintf('#<Set: {%s}>', empty? ? '' : '...')
-  end
+  end unless method_defined?(:pretty_print_cycle)
 end
 
 class << ENV # :nodoc:


### PR DESCRIPTION
These methods are defined for built-in `Set` class on Ruby 3.5.